### PR TITLE
fix: nan build errors on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ],
     "dependencies": {
         "bindings": "1.5.x",
-        "nan": "2.16.x",
+        "nan": "2.17.x",
         "stable": "^0.1.8"
     },
     "optionalDependencies": {


### PR DESCRIPTION
On install on windows theres several build errors beginning with: ...node_modules\nan\nan_callbacks.h(55,23): error C2039: 'AccessorSignature': is not a member of 'v8' ...
fixed by using newer nan version